### PR TITLE
(feature) Readme now explains security sensitivities

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,13 +5,15 @@ License: MIT
 License URI: https://opensource.org/licenses/MIT
 Requires PHP: 7
 
-Prevents the use of breached passwords by sending passwords to haveibeenpwned.com to be checked
+Prevents the use of breached passwords by sending passwords to haveibeenpwned.com to be checked.
 
 == Description ==
 
-This plugin sends all changed passwords to haveibeenpwned.com's API to check whether they've been breached or not. If a password has been breached, the user is unable to set it as their password. Passwords are only checked when being set or changed, not every time a user logs in.
+This plugin sends all changed password hashes to haveibeenpwned.com's API to check whether they've been breached or not. If a password has been breached, the user is unable to set it as their password. Passwords are only checked when being set or changed, not every time a user logs in.
 
-It's possible to use your own API by setting the `PASSWORD_CHECK_URL` constant:
+Using this plugin will send your hashed, unreadable password to haveibeenpwned.com in order to complete the check. If you're concerned about doing that, you can set up your own API with their data in order to do the checks privately.
+
+To do this, set the `PASSWORD_CHECK_URL` constant to the URL of your API endpoint:
 
 `define('PASSWORD_CHECK_URL', 'https://my-website.invalid/api/v2/pwnedpassword/%s');`
 
@@ -35,7 +37,7 @@ Install the plugin and activate it.
 
 Step 3:
 
-WordPress has a minimum password length of 1, and passwords are hashed using an MD5-based algorithm instead of a real password hashing algorithm (such as bcrypt, scrypt, or PBKDF2).
+WordPress has a minimum password length of 1, and passwords are hashed using an MD5-based algorithm instead of a more secure password hashing algorithm (such as bcrypt, scrypt, or PBKDF2).
 
 We recommend addressing those issues, but we don't recommend a particular plugin. However if you think WordPress should have these (basic) features, you should register your interest on the tickets:
 

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Prevents the use of breached passwords by sending passwords to haveibeenpwned.co
 
 This plugin sends all changed password hashes to haveibeenpwned.com's API to check whether they've been breached or not. If a password has been breached, the user is unable to set it as their password. Passwords are only checked when being set or changed, not every time a user logs in.
 
-Using this plugin will send your hashed, unreadable password to haveibeenpwned.com in order to complete the check. If you're concerned about doing that, you can set up your own API with their data in order to do the checks privately.
+Using this plugin will send the user's password (hashed with SHA1) to haveibeenpwned.com in order to complete the check. If you're concerned about doing that, you can set up your own API with their data in order to do the checks privately.
 
 To do this, set the `PASSWORD_CHECK_URL` constant to the URL of your API endpoint:
 

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,12 @@ To do this, set the `PASSWORD_CHECK_URL` constant to the URL of your API endpoin
 
 If the `PASSWORD_CHECK_URL` constant is unset, all passwords will be sent to haveibeenpwned.com.
 
+== Is this secure? ==
+
+[Security products don't have to be perfect, they just have to be better than not using them.](https://www.troyhunt.com/password-managers-dont-have-to-be-perfect-they-just-have-to-be-better-than-not-having-one/) Our guess is that for most WordPress sites they will gain more security from avoiding known compromised passwords than they will lose from submitting the passwords to HIBP.
+
+If submitting hashed passwords to HIBP is too much of a risk, you can use your own API (see installation instructions for how to do this).
+
 == Installation ==
 
 Step 1:


### PR DESCRIPTION
Not all users may want to send all their hashes to HIBP. The readme now contains a brief explanation.